### PR TITLE
Encode query parameter values

### DIFF
--- a/lib/modelHttpMixin.js
+++ b/lib/modelHttpMixin.js
@@ -201,7 +201,7 @@ var staticMethods = {
 
             }).map(function(pair) {
 
-                return pair.join('=');
+                return [pair[0], encodeURIComponent(pair[1])].join('=');
 
             }).join('&');
 

--- a/test/index.js
+++ b/test/index.js
@@ -555,12 +555,26 @@ describe('Generating model url', function() {
                 nullKey: null,
                 include: ['tags', 'tags.id']
             }
-        }), apiUrl + 'article/2?filter[title]=test&filter[published]=true&sort=-title&include=tags,tags.id');
+        }), apiUrl + 'article/2?filter[title]=test&filter[published]=true&sort=-title&include=tags%2Ctags.id');
+
+        assert.equal(Model.url({
+            type: 'article',
+            query: {
+                filter: {
+                    title: 'test # test',
+                }
+            }
+        }), apiUrl + 'article?filter[title]=test%20%23%20test');
 
         assert.equal(Model.url({
             type: 'article',
             query: 'filter[title]=test'
         }), apiUrl + 'article?filter[title]=test');
+
+        assert.equal(Model.url({
+            type: 'article',
+            query: 'filter[title]=test # test'
+        }), apiUrl + 'article?filter[title]=test # test');
 
     });
 


### PR DESCRIPTION
Query parameter special characters such as `#` are not encoded, e.g. `searchTerm=test # test` should be `searchTerm=test%20%23%20test`. This PR adds support for encoding query parameter values.